### PR TITLE
convert term_char to int.

### DIFF
--- a/vxi11/vxi11.py
+++ b/vxi11/vxi11.py
@@ -683,7 +683,7 @@ class Device(object):
 
         if self.term_char is not None:
             flags = OP_FLAG_TERMCHAR_SET
-            term_char = str(self.term_char).encode('utf-8')[0]
+            term_char = ord(str(self.term_char).encode('utf-8')[0])
 
         read_data = bytearray()
 


### PR DESCRIPTION
This is my first gpib project and also my first pull request.  If something doesn't feel right, its probably for good reason.

python 2.7.9
when:

instr = vxi11.Instrument('192.168.2.9', 'gpib0,3')
instr.term_char = '\n'
print instr.ask('ID')

i find that pack_int(term_char) of pack_device_read_parms() fails with a conversion error.

Best regards.