### PR TITLE
Fix terminal character type issue.

### DIFF
--- a/vxi11/vxi11.py
+++ b/vxi11/vxi11.py
@@ -662,7 +662,7 @@ class Device(object):
 
         if self.term_char is not None:
             flags = OP_FLAG_TERMCHAR_SET
-            term_char = str(self.term_char).encode('utf-8')[0]
+            term_char = str(self.term_char).encode('utf-8')[:1]
             data += term_char
 
         flags = 0


### PR DESCRIPTION
In python3, taking [0] to encoded string returns bytes type.
[:1] gives str of length 1.