### PR TITLE
Use `r` strings when constructing regex patterns

### DIFF
--- a/vxi11/vxi11.py
+++ b/vxi11/vxi11.py
@@ -131,8 +131,8 @@ def parse_visa_resource_string(resource_string):
     # TCPIP0::10.0.0.1::gpib,5::INSTR
     # TCPIP0::10.0.0.1::usb0::INSTR
     # TCPIP0::10.0.0.1::usb0[1234::5678::MYSERIAL::0]::INSTR
-    m = re.match('^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'
-            '(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<suffix>INSTR))$',
+    m = re.match(r'^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'
+            r'(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<suffix>INSTR))$',
             resource_string, re.I)
 
     if m is not None:


### PR DESCRIPTION
Python 3.11 was complaining `invalid escape sequence '\d'`